### PR TITLE
define variable 'definition' in get_ko_name()

### DIFF
--- a/src/aux.py
+++ b/src/aux.py
@@ -347,6 +347,7 @@ def get_fastaProt(response):
 
 
 def get_ko_name(response):
+    definition = ""
     html = response.read()
     b = bs(html, features="html.parser")
     rows = b.findAll("tr")


### PR DESCRIPTION
Python throws an error if the variable is not pre-defined when it doesn't get all the way to the end of the for loop in get_ko_name() to assign a value to it.